### PR TITLE
Dev

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,8 +110,11 @@ Create a `.env` in your project directory. Keep it private and never commit it.
 | Submit intents | `ORION_VAULT_ADDRESS`, `STRATEGIST_PRIVATE_KEY` |
 | LP deposit / redeem | `ORION_VAULT_ADDRESS`, `LP_PRIVATE_KEY` |
 | Read vault data | Pass `contract_address=` in Python, or set `ORION_VAULT_ADDRESS` |
+| Estimate execution cost | Optional `MAINNET_RPC_URL` (public mainnet RPCs if unset) |
 
 **`RPC_URL` (optional).** If unset, the SDK probes default public Sepolia RPCs (`1rpc.io` → `0xrpc.io` → `publicnode` → `stupidtech`), matching `install.sh`. Set your own endpoint for higher rate limits, other networks, or long historical series.
+
+**`MAINNET_RPC_URL` (optional).** Used for execution-cost estimates. If unset, the SDK probes public Ethereum mainnet RPCs (`publicnode` → Alchemy public → `1rpc` → `drpc`). Set an archival endpoint for historical `timestamp` queries and higher rate limits.
 
 ### Getting an RPC URL (optional)
 
@@ -328,7 +331,7 @@ Estimate Uniswap v3 execution cost (pool fee plus price impact) for a signed tra
 
 `signed_size` is human units of the risk asset: positive buys that many tokens (exact-output, matching adapter `buy`), negative sells them (exact-input, matching adapter `sell`).
 
-When constructing `ExecutionCostEstimator` without an explicit `rpc_url`, `MAINNET_RPC_URL` must be set to a non-empty Ethereum mainnet RPC endpoint.
+When constructing `ExecutionCostEstimator` without an explicit `rpc_url` or `MAINNET_RPC_URL`, the SDK probes public Ethereum mainnet RPCs (`publicnode` → Alchemy public → `1rpc` → `drpc`). Set `MAINNET_RPC_URL` to an archival endpoint for historical `timestamp` queries and higher rate limits — public RPCs often cannot serve old `eth_call` snapshots.
 
 ```python
 from orion_finance_sdk_py import ExecutionCostEstimator

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ orion --help
 Or install from PyPI:
 
 ```bash
-pip install "orion-finance-sdk-py>=2.0.0"
+pip install "orion-finance-sdk-py>=2.1.1"
 ```
 :::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "orion-finance-sdk-py"
-version = "2.1.0"
+version = "2.1.1"
 requires-python = ">=3.11,<3.14"
 readme = "README.md"
 authors = [

--- a/python/orion_finance_sdk_py/costs/estimator.py
+++ b/python/orion_finance_sdk_py/costs/estimator.py
@@ -26,7 +26,7 @@ from orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state import (
 )
 from orion_finance_sdk_py.costs.venues.uniswap_v3.rpc import connect_mainnet
 from orion_finance_sdk_py.costs.venues.uniswap_v3.simulator import simulate_asset_swap
-from orion_finance_sdk_py.rpc import block_at_timestamp
+from orion_finance_sdk_py.rpc import block_at_timestamp, pick_default_mainnet_rpc
 
 load_dotenv()
 
@@ -36,9 +36,12 @@ _SUPPORTED_VENUES = frozenset({"uniswap_v3"})
 class ExecutionCostEstimator:
     """Manager-facing execution cost estimator.
 
-    v1 wraps Uniswap v3 on Ethereum mainnet (the venue Orion will use). Set
-    ``MAINNET_RPC_URL`` to an archival endpoint. Optional ``block_number`` pins
-    snapshots for research reproducibility and is not part of ``get_cost``.
+    v1 wraps Uniswap v3 on Ethereum mainnet (the venue Orion will use). If
+    ``rpc_url`` and ``MAINNET_RPC_URL`` are unset, public mainnet RPCs are
+    probed in order. Set ``MAINNET_RPC_URL`` to an archival endpoint for
+    historical ``timestamp`` queries and higher rate limits. Optional
+    ``block_number`` pins snapshots for research reproducibility and is not
+    part of ``get_cost``.
     """
 
     def __init__(
@@ -56,12 +59,17 @@ class ExecutionCostEstimator:
 
     def _web3(self) -> Web3:
         if self._w3 is None:
-            if not self._rpc_url:
+            url = self._rpc_url
+            if not url:
+                url = (pick_default_mainnet_rpc() or "").strip()
+                self._rpc_url = url
+            if not url:
                 raise RuntimeError(
-                    "MAINNET_RPC_URL is required for execution cost estimates. "
-                    "Set it to an archival Ethereum mainnet RPC."
+                    "No public Ethereum mainnet RPC responded. Set "
+                    "MAINNET_RPC_URL to an Ethereum mainnet RPC "
+                    "(archival for historical timestamps)."
                 )
-            self._w3 = connect_mainnet(self._rpc_url)
+            self._w3 = connect_mainnet(url)
         return self._w3
 
     def preload_uniswap_state(self, symbol: str, state: PoolState) -> None:

--- a/python/orion_finance_sdk_py/rpc.py
+++ b/python/orion_finance_sdk_py/rpc.py
@@ -15,13 +15,23 @@ DEFAULT_PUBLIC_RPC_URLS: tuple[str, ...] = (
     "https://evm.stupidtech.net/v1/11155111",
 )
 
+# Public Ethereum mainnet endpoints for read-only cost estimates.
+DEFAULT_PUBLIC_MAINNET_RPC_URLS: tuple[str, ...] = (
+    "https://ethereum-rpc.publicnode.com",
+    "https://eth-mainnet.g.alchemy.com/public",
+    "https://public.1rpc.io/eth",
+    "https://eth.drpc.org/",
+)
+
 _DEFAULT_RPC_CACHE: str | None = None
+_DEFAULT_MAINNET_RPC_CACHE: str | None = None
 
 
 def clear_default_rpc_cache() -> None:
-    """Clear the process-level cached default RPC URL (for tests)."""
-    global _DEFAULT_RPC_CACHE
+    """Clear process-level cached default RPC URLs (for tests)."""
+    global _DEFAULT_RPC_CACHE, _DEFAULT_MAINNET_RPC_CACHE
     _DEFAULT_RPC_CACHE = None
+    _DEFAULT_MAINNET_RPC_CACHE = None
 
 
 def rpc_works(url: str, timeout: float = 5.0) -> bool:
@@ -35,21 +45,42 @@ def rpc_works(url: str, timeout: float = 5.0) -> bool:
         return False
 
 
+def _pick_first_working(
+    urls: tuple[str, ...], cache: str | None, timeout: float
+) -> tuple[str | None, str | None]:
+    """Return ``(chosen_url, updated_cache)``. ``cache`` is reused when set."""
+    if cache is not None:
+        return cache, cache
+    for url in urls:
+        if rpc_works(url, timeout=timeout):
+            return url, url
+    return None, None
+
+
 def pick_default_rpc(timeout: float = 5.0) -> str | None:
-    """Probe default public RPCs in order; return the first that works (cached).
+    """Probe default public Sepolia RPCs in order; return the first that works (cached).
 
     Returns:
         A working RPC URL, or ``None`` if every default endpoint failed.
     """
     global _DEFAULT_RPC_CACHE
-    if _DEFAULT_RPC_CACHE is not None:
-        return _DEFAULT_RPC_CACHE
+    url, _DEFAULT_RPC_CACHE = _pick_first_working(
+        DEFAULT_PUBLIC_RPC_URLS, _DEFAULT_RPC_CACHE, timeout
+    )
+    return url
 
-    for url in DEFAULT_PUBLIC_RPC_URLS:
-        if rpc_works(url, timeout=timeout):
-            _DEFAULT_RPC_CACHE = url
-            return url
-    return None
+
+def pick_default_mainnet_rpc(timeout: float = 5.0) -> str | None:
+    """Probe default public mainnet RPCs in order; return the first that works (cached).
+
+    Returns:
+        A working RPC URL, or ``None`` if every default endpoint failed.
+    """
+    global _DEFAULT_MAINNET_RPC_CACHE
+    url, _DEFAULT_MAINNET_RPC_CACHE = _pick_first_working(
+        DEFAULT_PUBLIC_MAINNET_RPC_URLS, _DEFAULT_MAINNET_RPC_CACHE, timeout
+    )
+    return url
 
 
 def block_at_timestamp(w3: Web3, timestamp: int) -> int:

--- a/python/orion_finance_sdk_py/utils.py
+++ b/python/orion_finance_sdk_py/utils.py
@@ -32,7 +32,7 @@ def ensure_env_file(env_file_path: Path = Path.cwd() / ".env"):
 # RPC URL for testnet connection
 RPC_URL=
 
-# RPC for execution cost estimates
+# Optional RPC for execution cost estimates (public mainnet RPCs if unset)
 # MAINNET_RPC_URL=
 
 # Private key for manager operations

--- a/tests/test_cost_registry.py
+++ b/tests/test_cost_registry.py
@@ -1,13 +1,20 @@
 """Tests for execution-cost symbol resolution."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from orion_finance_sdk_py.costs.registry import resolve_symbol
+from orion_finance_sdk_py.costs.registry import resolve_symbol, resolve_symbol_onchain
 from orion_finance_sdk_py.costs.venues.uniswap_v3.constants import (
+    USDC_ADDRESS,
     WBTC_ADDRESS,
     WBTC_USDC_POOL,
     WETH_ADDRESS,
     WETH_USDC_POOL,
 )
+from orion_finance_sdk_py.types import ZERO_ADDRESS
+
+UNKNOWN = "0x0000000000000000000000000000000000000001"
+UNKNOWN_POOL = "0x1111111111111111111111111111111111111111"
 
 
 def test_resolve_ticker_weth():
@@ -58,4 +65,76 @@ def test_unknown_ticker():
 def test_unknown_address_not_sepolia_guess():
     # A random mainnet-shaped address is not silently treated as a twin.
     with pytest.raises(KeyError, match="Unknown mainnet asset"):
-        resolve_symbol("0x0000000000000000000000000000000000000001")
+        resolve_symbol(UNKNOWN)
+
+
+def test_resolve_symbol_requires_value():
+    with pytest.raises(ValueError, match="symbol is required"):
+        resolve_symbol("")
+    with pytest.raises(ValueError, match="symbol is required"):
+        resolve_symbol("   ")
+
+
+def test_resolve_symbol_onchain_uses_static_map_for_known_ticker():
+    w3 = MagicMock()
+    spec = resolve_symbol_onchain("WETH", w3, 1)
+    assert spec.symbol == "WETH"
+    w3.eth.call.assert_not_called()
+
+
+def test_resolve_symbol_onchain_unknown_ticker():
+    with pytest.raises(KeyError, match="Unknown symbol"):
+        resolve_symbol_onchain("NOTACOIN", MagicMock(), 1)
+
+
+def test_resolve_symbol_onchain_factory_hit():
+    w3 = MagicMock()
+    with (
+        patch(
+            "orion_finance_sdk_py.costs.registry.factory_get_pool",
+            return_value=UNKNOWN_POOL,
+        ) as factory,
+        patch(
+            "orion_finance_sdk_py.costs.registry.erc20_symbol",
+            return_value="FOO",
+        ),
+    ):
+        spec = resolve_symbol_onchain(UNKNOWN, w3, 12)
+    assert spec.symbol == "FOO"
+    assert spec.address == UNKNOWN
+    assert spec.pool == UNKNOWN_POOL
+    assert spec.fee == 500
+    factory.assert_called_once()
+
+
+def test_resolve_symbol_onchain_symbol_lookup_falls_back_to_address():
+    w3 = MagicMock()
+    with (
+        patch(
+            "orion_finance_sdk_py.costs.registry.factory_get_pool",
+            return_value=UNKNOWN_POOL,
+        ),
+        patch(
+            "orion_finance_sdk_py.costs.registry.erc20_symbol",
+            side_effect=RuntimeError("no symbol"),
+        ),
+    ):
+        spec = resolve_symbol_onchain(UNKNOWN, w3, 1)
+    assert spec.symbol == UNKNOWN
+
+
+def test_resolve_symbol_onchain_no_pool():
+    w3 = MagicMock()
+    with patch(
+        "orion_finance_sdk_py.costs.registry.factory_get_pool",
+        return_value=ZERO_ADDRESS,
+    ):
+        with pytest.raises(KeyError, match="No Uniswap v3 USDC pool"):
+            resolve_symbol_onchain(UNKNOWN, w3, 1)
+
+
+def test_resolve_symbol_onchain_rejects_usdc():
+    with pytest.raises(ValueError, match="quote asset"):
+        resolve_symbol_onchain("USDC", MagicMock(), 1)
+    with pytest.raises(ValueError, match="quote asset"):
+        resolve_symbol_onchain(USDC_ADDRESS, MagicMock(), 1)

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -199,19 +199,43 @@ def test_unsupported_venue():
         est.get_cost("WETH", 0.01, venue="bebop_rfq")
 
 
-def test_web3_requires_mainnet_rpc(monkeypatch):
+def test_web3_uses_public_mainnet_rpc_when_env_unset(monkeypatch):
     monkeypatch.delenv("MAINNET_RPC_URL", raising=False)
     est = ExecutionCostEstimator()
-    with pytest.raises(RuntimeError, match="MAINNET_RPC_URL"):
-        est._web3()
+    fake = MagicMock()
+    with (
+        patch.object(
+            estimator_mod,
+            "pick_default_mainnet_rpc",
+            return_value="https://public.example",
+        ) as picker,
+        patch.object(estimator_mod, "connect_mainnet", return_value=fake) as mocked,
+    ):
+        assert est._web3() is fake
+        assert est._web3() is fake
+    picker.assert_called_once()
+    mocked.assert_called_once_with("https://public.example")
+    assert est._rpc_url == "https://public.example"
+
+
+def test_web3_errors_when_public_mainnet_rpcs_fail(monkeypatch):
+    monkeypatch.delenv("MAINNET_RPC_URL", raising=False)
+    est = ExecutionCostEstimator()
+    with patch.object(estimator_mod, "pick_default_mainnet_rpc", return_value=None):
+        with pytest.raises(RuntimeError, match="public Ethereum mainnet RPC"):
+            est._web3()
 
 
 def test_web3_connects_and_caches():
     est = ExecutionCostEstimator(rpc_url="https://example.invalid")
     fake = MagicMock()
-    with patch.object(estimator_mod, "connect_mainnet", return_value=fake) as mocked:
+    with (
+        patch.object(estimator_mod, "pick_default_mainnet_rpc") as picker,
+        patch.object(estimator_mod, "connect_mainnet", return_value=fake) as mocked,
+    ):
         assert est._web3() is fake
         assert est._web3() is fake
+    picker.assert_not_called()
     mocked.assert_called_once_with("https://example.invalid")
 
 

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from orion_finance_sdk_py.costs.estimator import ExecutionCostEstimator
+from orion_finance_sdk_py.costs import estimator as estimator_mod
+from orion_finance_sdk_py.costs.estimator import ExecutionCostEstimator, get_cost
+from orion_finance_sdk_py.costs.registry import VenueAsset, resolve_symbol
 from orion_finance_sdk_py.costs.types import ExecutionCost
 from orion_finance_sdk_py.costs.venues.uniswap_v3.constants import (
     USDC_ADDRESS,
@@ -16,6 +18,8 @@ from orion_finance_sdk_py.costs.venues.uniswap_v3.constants import (
     WETH_ADDRESS,
     WETH_USDC_POOL,
 )
+
+UNKNOWN_ADDR = "0x0000000000000000000000000000000000000001"
 from orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state import PoolMeta, PoolState
 from orion_finance_sdk_py.costs.venues.uniswap_v3.v3_math.tick_math import (
     get_sqrt_ratio_at_tick,
@@ -193,6 +197,165 @@ def test_unsupported_venue():
     est = _estimator()
     with pytest.raises(ValueError, match="Unsupported venue"):
         est.get_cost("WETH", 0.01, venue="bebop_rfq")
+
+
+def test_web3_requires_mainnet_rpc(monkeypatch):
+    monkeypatch.delenv("MAINNET_RPC_URL", raising=False)
+    est = ExecutionCostEstimator()
+    with pytest.raises(RuntimeError, match="MAINNET_RPC_URL"):
+        est._web3()
+
+
+def test_web3_connects_and_caches():
+    est = ExecutionCostEstimator(rpc_url="https://example.invalid")
+    fake = MagicMock()
+    with patch.object(estimator_mod, "connect_mainnet", return_value=fake) as mocked:
+        assert est._web3() is fake
+        assert est._web3() is fake
+    mocked.assert_called_once_with("https://example.invalid")
+
+
+def test_netting_eta_must_be_unit_interval():
+    est = _estimator()
+    with pytest.raises(ValueError, match="netting_eta"):
+        est.get_cost("WETH", 0.01, netting_eta=-0.1)
+    with pytest.raises(ValueError, match="netting_eta"):
+        est.get_cost("WETH", 0.01, netting_eta=1.1)
+
+
+def test_module_get_cost_wrapper():
+    est = _estimator()
+    previous = estimator_mod._DEFAULT_ESTIMATOR
+    estimator_mod._DEFAULT_ESTIMATOR = est
+    try:
+        cost = get_cost("WETH", 0.01, timestamp="2026-08-01")
+        assert cost.symbol == "WETH"
+        assert cost.cost_pct > 0
+    finally:
+        estimator_mod._DEFAULT_ESTIMATOR = previous
+
+
+def test_module_get_cost_creates_default_estimator(monkeypatch):
+    previous = estimator_mod._DEFAULT_ESTIMATOR
+    estimator_mod._DEFAULT_ESTIMATOR = None
+
+    def _fake_get_cost(self, *args, **kwargs):
+        return MagicMock(symbol="WETH")
+
+    monkeypatch.setattr(ExecutionCostEstimator, "get_cost", _fake_get_cost)
+    try:
+        out = get_cost("WETH", 0.01)
+        assert out.symbol == "WETH"
+        assert estimator_mod._DEFAULT_ESTIMATOR is not None
+    finally:
+        estimator_mod._DEFAULT_ESTIMATOR = previous
+
+
+def test_preload_unknown_symbol_on_usdc_pair():
+    est = ExecutionCostEstimator(block_number=1)
+    est.preload_uniswap_state("FAKE", _weth_usdc_state())
+    assert est._extra_assets["WETH"].symbol == "WETH"
+    est.preload_uniswap_state("ALSOFAKE", _wbtc_usdc_state())
+    assert est._extra_assets["WBTC"].symbol == "WBTC"
+
+
+def test_preload_unknown_address_uses_checksum_address():
+    est = ExecutionCostEstimator(block_number=1)
+    est.preload_uniswap_state(UNKNOWN_ADDR, _weth_usdc_state())
+    spec = est._extra_assets[UNKNOWN_ADDR.lower()]
+    assert spec.address == UNKNOWN_ADDR
+    assert spec.symbol == "WETH"
+
+
+def test_preload_rejects_non_usdc_pair():
+    est = ExecutionCostEstimator(block_number=1)
+    meta = PoolMeta(
+        address=WETH_USDC_POOL,
+        token0=WBTC_ADDRESS,
+        token1=WETH_ADDRESS,
+        fee=500,
+        decimals0=8,
+        decimals1=18,
+        tick_spacing=10,
+        symbol0="WBTC",
+        symbol1="WETH",
+    )
+    state = PoolState(
+        meta=meta,
+        block_number=1,
+        sqrt_price_x96=_SQRT_PRICE_X96,
+        tick=0,
+        liquidity=10**22,
+    )
+    with pytest.raises(ValueError, match="not an USDC pair"):
+        est.preload_uniswap_state("FOO", state)
+
+
+def test_snapshot_fetches_caches_and_rejects_zero_liquidity():
+    est = ExecutionCostEstimator(rpc_url="https://example.invalid", block_number=1)
+    est._w3 = MagicMock()
+    spec = resolve_symbol("WETH")
+    live = _weth_usdc_state()
+    calls = {"n": 0}
+
+    def _fetch(_w3, _meta, _block):
+        calls["n"] += 1
+        return live
+
+    with (
+        patch.object(estimator_mod, "enrich_pool_meta", lambda w3, meta, block: meta),
+        patch.object(estimator_mod, "fetch_pool_state", _fetch),
+    ):
+        first = est._snapshot(spec, 1)
+        second = est._snapshot(spec, 1)
+    assert first is live
+    assert second is live
+    assert calls["n"] == 1
+
+    empty = _weth_usdc_state()
+    empty.liquidity = 0
+    est2 = ExecutionCostEstimator(rpc_url="https://example.invalid", block_number=1)
+    est2._w3 = MagicMock()
+    with (
+        patch.object(estimator_mod, "enrich_pool_meta", lambda w3, meta, block: meta),
+        patch.object(estimator_mod, "fetch_pool_state", lambda w3, meta, block: empty),
+    ):
+        with pytest.raises(RuntimeError, match="zero liquidity"):
+            est2._snapshot(spec, 1)
+
+
+def test_resolve_asset_unknown_address_uses_onchain():
+    est = _estimator()
+    fake = VenueAsset("FOO", UNKNOWN_ADDR, WETH_USDC_POOL, 500)
+    with patch.object(
+        estimator_mod, "resolve_symbol_onchain", return_value=fake
+    ) as mocked:
+        spec = est._resolve_asset(UNKNOWN_ADDR, 1)
+    assert spec is fake
+    mocked.assert_called_once()
+
+
+def test_resolve_block_without_override_uses_timestamp_lookup():
+    est = ExecutionCostEstimator(rpc_url="https://example.invalid")
+    est._w3 = MagicMock()
+    with patch.object(estimator_mod, "block_at_timestamp", return_value=99) as mocked:
+        assert est._resolve_block(1_700_000_000) == 99
+    mocked.assert_called_once()
+
+
+def test_resolve_block_honors_override():
+    est = ExecutionCostEstimator(block_number=42)
+    assert est._resolve_block(1_700_000_000) == 42
+
+
+def test_get_cost_without_block_override_looks_up_timestamp():
+    est = ExecutionCostEstimator()
+    est.preload_uniswap_state("WETH", _weth_usdc_state())
+    est._w3 = MagicMock()
+    with patch.object(estimator_mod, "block_at_timestamp", return_value=1):
+        cost = est.get_cost("WETH", 0.01, timestamp="2026-08-01")
+    assert cost.timestamp == "2026-08-01"
+    assert cost.cost_pct > 0
 
 
 @pytest.mark.integration

--- a/tests/test_pool_state.py
+++ b/tests/test_pool_state.py
@@ -1,0 +1,161 @@
+"""Tests for Uniswap v3 pool snapshot fetch helpers."""
+
+from unittest.mock import MagicMock, patch
+
+from eth_abi import encode
+from orion_finance_sdk_py.costs.venues.uniswap_v3.constants import (
+    MIN_TICK,
+    USDC_ADDRESS,
+    WBTC_ADDRESS,
+    WETH_ADDRESS,
+    WETH_USDC_POOL,
+)
+from orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state import (
+    PoolMeta,
+    _compress_tick,
+    _decompress_tick,
+    _resolve_usdc_side,
+    _token_symbol,
+    enrich_pool_meta,
+    fetch_pool_state,
+    fetch_tick_liquidity_net,
+    scan_initialized_ticks,
+)
+from orion_finance_sdk_py.costs.venues.uniswap_v3.rpc import TICK_INFO_TYPES
+
+_SQRT = 1905189324021806733252815214030137
+
+
+def _tick_info(net: int) -> bytes:
+    return encode(TICK_INFO_TYPES, [0, net, 0, 0, 0, 0, 0, False])
+
+
+def test_compress_tick_rounds_negative_non_multiples_down():
+    assert _compress_tick(-11, 10) == -3
+    assert _decompress_tick(-3, 10) == -30
+    assert _compress_tick(10, 10) == 1
+    assert _decompress_tick(1, 10) == 10
+
+
+def test_scan_initialized_ticks_skips_none_and_zero_bitmap():
+    spacing = 10
+    min_word = _compress_tick(MIN_TICK, spacing) >> 8
+    idx_word0 = 0 - min_word
+
+    def fake_multicall(_w3, calls, _block, batch_size=500):
+        results: list[bytes | None] = [None] * len(calls)
+        results[idx_word0] = encode(["uint256"], [1])
+        if idx_word0 + 1 < len(results):
+            results[idx_word0 + 1] = encode(["uint256"], [0])
+        return results
+
+    with patch(
+        "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.multicall_aggregate3",
+        side_effect=fake_multicall,
+    ):
+        ticks = scan_initialized_ticks(MagicMock(), WETH_USDC_POOL, spacing, 1)
+    assert ticks == [0]
+
+
+def test_fetch_tick_liquidity_net_skips_bad_rows_and_zero_net():
+    ticks = [10, 20, 30, 40]
+    results = [
+        None,
+        b"\x00" * 32,
+        _tick_info(0),
+        _tick_info(-123),
+    ]
+
+    with patch(
+        "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.multicall_aggregate3",
+        return_value=results,
+    ):
+        net = fetch_tick_liquidity_net(MagicMock(), WETH_USDC_POOL, ticks, 1)
+    assert net == {40: -123}
+
+
+def test_resolve_usdc_side_token0_token1_and_neither():
+    meta = PoolMeta(address=WETH_USDC_POOL, token0=USDC_ADDRESS, token1=WETH_ADDRESS)
+    _resolve_usdc_side(meta)
+    assert meta.stable_token == USDC_ADDRESS
+
+    meta = PoolMeta(address=WETH_USDC_POOL, token0=WBTC_ADDRESS, token1=USDC_ADDRESS)
+    _resolve_usdc_side(meta)
+    assert meta.stable_token == USDC_ADDRESS
+
+    meta = PoolMeta(address=WETH_USDC_POOL, token0=WBTC_ADDRESS, token1=WETH_ADDRESS)
+    _resolve_usdc_side(meta)
+    assert meta.stable_token is None
+
+
+def test_token_symbol_falls_back_to_address_suffix():
+    with patch(
+        "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.erc20_symbol",
+        side_effect=RuntimeError("no symbol"),
+    ):
+        assert _token_symbol(MagicMock(), WETH_ADDRESS, 1) == WETH_ADDRESS[-4:]
+
+
+def test_enrich_pool_meta_fills_tokens_and_usdc_side():
+    meta = PoolMeta(address=WETH_USDC_POOL)
+    with (
+        patch(
+            "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.pool_token",
+            side_effect=[USDC_ADDRESS, WETH_ADDRESS],
+        ),
+        patch(
+            "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.pool_fee",
+            return_value=500,
+        ),
+        patch(
+            "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.pool_tick_spacing",
+            return_value=10,
+        ),
+        patch(
+            "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.erc20_decimals",
+            side_effect=[6, 18],
+        ),
+        patch(
+            "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.erc20_symbol",
+            side_effect=["USDC", "WETH"],
+        ),
+    ):
+        out = enrich_pool_meta(MagicMock(), meta, 1)
+    assert out.token0 == USDC_ADDRESS
+    assert out.token1 == WETH_ADDRESS
+    assert out.fee == 500
+    assert out.tick_spacing == 10
+    assert out.decimals0 == 6
+    assert out.decimals1 == 18
+    assert out.symbol0 == "USDC"
+    assert out.symbol1 == "WETH"
+    assert out.stable_token == USDC_ADDRESS
+
+
+def test_fetch_pool_state_assembles_snapshot():
+    meta = PoolMeta(address=WETH_USDC_POOL, tick_spacing=10, fee=500)
+    with (
+        patch(
+            "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.pool_slot0",
+            return_value=(_SQRT, 100),
+        ),
+        patch(
+            "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.pool_liquidity",
+            return_value=10**22,
+        ),
+        patch(
+            "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.scan_initialized_ticks",
+            return_value=[90, 110],
+        ),
+        patch(
+            "orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state.fetch_tick_liquidity_net",
+            return_value={90: 1, 110: -1},
+        ),
+    ):
+        state = fetch_pool_state(MagicMock(), meta, 7)
+    assert state.block_number == 7
+    assert state.sqrt_price_x96 == _SQRT
+    assert state.tick == 100
+    assert state.liquidity == 10**22
+    assert state.initialized_ticks == [90, 110]
+    assert state.tick_liquidity_net == {90: 1, 110: -1}

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -3,8 +3,10 @@
 from unittest.mock import MagicMock, patch
 
 from orion_finance_sdk_py.rpc import (
+    DEFAULT_PUBLIC_MAINNET_RPC_URLS,
     DEFAULT_PUBLIC_RPC_URLS,
     clear_default_rpc_cache,
+    pick_default_mainnet_rpc,
     pick_default_rpc,
     rpc_works,
 )
@@ -58,3 +60,52 @@ def test_pick_default_rpc_tries_in_order_and_caches():
 def test_pick_default_rpc_returns_none_when_all_fail():
     with patch("orion_finance_sdk_py.rpc.rpc_works", return_value=False):
         assert pick_default_rpc() is None
+
+
+def test_default_public_mainnet_rpc_urls_order():
+    assert DEFAULT_PUBLIC_MAINNET_RPC_URLS == (
+        "https://ethereum-rpc.publicnode.com",
+        "https://eth-mainnet.g.alchemy.com/public",
+        "https://public.1rpc.io/eth",
+        "https://eth.drpc.org/",
+    )
+
+
+def test_pick_default_mainnet_rpc_tries_in_order_and_caches():
+    calls: list[str] = []
+
+    def _works(url, timeout=5.0):
+        calls.append(url)
+        return url == DEFAULT_PUBLIC_MAINNET_RPC_URLS[1]
+
+    with patch("orion_finance_sdk_py.rpc.rpc_works", side_effect=_works):
+        assert pick_default_mainnet_rpc() == DEFAULT_PUBLIC_MAINNET_RPC_URLS[1]
+        assert pick_default_mainnet_rpc() == DEFAULT_PUBLIC_MAINNET_RPC_URLS[1]
+
+    assert calls == [
+        DEFAULT_PUBLIC_MAINNET_RPC_URLS[0],
+        DEFAULT_PUBLIC_MAINNET_RPC_URLS[1],
+    ]
+
+
+def test_pick_default_mainnet_rpc_returns_none_when_all_fail():
+    with patch("orion_finance_sdk_py.rpc.rpc_works", return_value=False):
+        assert pick_default_mainnet_rpc() is None
+
+
+def test_clear_default_rpc_cache_resets_mainnet_cache():
+    with patch(
+        "orion_finance_sdk_py.rpc.rpc_works",
+        return_value=True,
+    ):
+        assert pick_default_mainnet_rpc() == DEFAULT_PUBLIC_MAINNET_RPC_URLS[0]
+    clear_default_rpc_cache()
+    calls: list[str] = []
+
+    def _works(url, timeout=5.0):
+        calls.append(url)
+        return True
+
+    with patch("orion_finance_sdk_py.rpc.rpc_works", side_effect=_works):
+        assert pick_default_mainnet_rpc() == DEFAULT_PUBLIC_MAINNET_RPC_URLS[0]
+    assert calls == [DEFAULT_PUBLIC_MAINNET_RPC_URLS[0]]

--- a/tests/test_uniswap_v3_math.py
+++ b/tests/test_uniswap_v3_math.py
@@ -1,9 +1,56 @@
 """Unit tests for Uniswap v3 math ported into the SDK."""
 
+import pytest
+from orion_finance_sdk_py.costs.venues.uniswap_v3.constants import (
+    MAX_SQRT_RATIO,
+    MAX_TICK,
+    MIN_SQRT_RATIO,
+    MIN_TICK,
+)
+from orion_finance_sdk_py.costs.venues.uniswap_v3.v3_math.sqrt_price_math import (
+    get_amount0_delta,
+    get_next_sqrt_price_from_amount0_rounding_up,
+    get_next_sqrt_price_from_input,
+    get_next_sqrt_price_from_output,
+)
 from orion_finance_sdk_py.costs.venues.uniswap_v3.v3_math.tick_math import (
     get_sqrt_ratio_at_tick,
+    get_tick_at_sqrt_ratio,
 )
 
 
 def test_get_sqrt_ratio_at_tick_zero():
     assert get_sqrt_ratio_at_tick(0) == 79228162514264337593543950336
+
+
+def test_get_sqrt_ratio_at_tick_positive_and_bounds():
+    assert get_sqrt_ratio_at_tick(1) > get_sqrt_ratio_at_tick(0)
+    with pytest.raises(ValueError, match="out of bounds"):
+        get_sqrt_ratio_at_tick(MIN_TICK - 1)
+    with pytest.raises(ValueError, match="out of bounds"):
+        get_sqrt_ratio_at_tick(MAX_TICK + 1)
+
+
+def test_get_tick_at_sqrt_ratio_bounds():
+    assert get_tick_at_sqrt_ratio(MIN_SQRT_RATIO) == MIN_TICK
+    with pytest.raises(ValueError, match="sqrt price out of bounds"):
+        get_tick_at_sqrt_ratio(MIN_SQRT_RATIO - 1)
+    with pytest.raises(ValueError, match="sqrt price out of bounds"):
+        get_tick_at_sqrt_ratio(MAX_SQRT_RATIO)
+
+
+def test_sqrt_price_math_zero_amount_and_invalid_liquidity():
+    px = get_sqrt_ratio_at_tick(0)
+    assert get_next_sqrt_price_from_amount0_rounding_up(px, 10**18, 0, True) == px
+    with pytest.raises(ValueError, match="invalid price or liquidity"):
+        get_next_sqrt_price_from_input(0, 1, 1, True)
+    with pytest.raises(ValueError, match="invalid price or liquidity"):
+        get_next_sqrt_price_from_output(px, 0, 1, True)
+
+
+def test_get_amount0_delta_sorts_ratios():
+    a = get_sqrt_ratio_at_tick(10)
+    b = get_sqrt_ratio_at_tick(0)
+    assert get_amount0_delta(a, b, 10**18, False) == get_amount0_delta(
+        b, a, 10**18, False
+    )

--- a/tests/test_uniswap_v3_rpc.py
+++ b/tests/test_uniswap_v3_rpc.py
@@ -1,0 +1,147 @@
+"""Mocked unit tests for Uniswap v3 archival RPC helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from eth_abi import encode
+from orion_finance_sdk_py.costs.venues.uniswap_v3.constants import (
+    MULTICALL3_ADDRESS,
+    USDC_ADDRESS,
+    WETH_ADDRESS,
+    WETH_USDC_POOL,
+)
+from orion_finance_sdk_py.costs.venues.uniswap_v3.rpc import (
+    connect_mainnet,
+    encode_call,
+    factory_get_pool,
+    multicall_aggregate3,
+    pool_fee,
+    pool_liquidity,
+    pool_slot0,
+    pool_tick_spacing,
+    pool_token,
+)
+from web3.exceptions import ContractLogicError
+
+FACTORY = "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+
+
+def _w3_returning(payload: bytes) -> MagicMock:
+    w3 = MagicMock()
+    w3.eth.call.return_value = payload
+    return w3
+
+
+def test_encode_call_with_and_without_0x_prefix():
+    assert encode_call("0x3850c7bd") == bytes.fromhex("3850c7bd")
+    assert encode_call("3850c7bd") == bytes.fromhex("3850c7bd")
+    assert (
+        encode_call("0x3850c7bd", b"\x01\x02")
+        == bytes.fromhex("3850c7bd") + b"\x01\x02"
+    )
+
+
+def test_connect_mainnet_accepts_chain_id_1():
+    with patch("orion_finance_sdk_py.costs.venues.uniswap_v3.rpc.Web3") as mock_web3:
+        instance = MagicMock()
+        instance.is_connected.return_value = True
+        instance.eth.chain_id = 1
+        mock_web3.return_value = instance
+        assert connect_mainnet("https://example.invalid") is instance
+
+
+def test_connect_mainnet_rejects_disconnected():
+    with patch("orion_finance_sdk_py.costs.venues.uniswap_v3.rpc.Web3") as mock_web3:
+        instance = MagicMock()
+        instance.is_connected.return_value = False
+        mock_web3.return_value = instance
+        with pytest.raises(RuntimeError, match="Failed to connect"):
+            connect_mainnet("https://example.invalid")
+
+
+def test_connect_mainnet_rejects_wrong_chain():
+    with patch("orion_finance_sdk_py.costs.venues.uniswap_v3.rpc.Web3") as mock_web3:
+        instance = MagicMock()
+        instance.is_connected.return_value = True
+        instance.eth.chain_id = 11155111
+        mock_web3.return_value = instance
+        with pytest.raises(RuntimeError, match="chain_id=1"):
+            connect_mainnet("https://example.invalid")
+
+
+def test_pool_slot0_decodes_sqrt_price_and_tick():
+    raw = encode(
+        ["uint160", "int24", "uint16", "uint16", "uint16", "uint8", "bool"],
+        [123456, -10, 0, 0, 0, 0, True],
+    )
+    sqrt_price, tick = pool_slot0(_w3_returning(raw), WETH_USDC_POOL, 1)
+    assert sqrt_price == 123456
+    assert tick == -10
+
+
+def test_pool_liquidity_tick_spacing_fee_and_token():
+    w3 = _w3_returning(encode(["uint128"], [99]))
+    assert pool_liquidity(w3, WETH_USDC_POOL, 1) == 99
+
+    w3 = _w3_returning(encode(["int24"], [10]))
+    assert pool_tick_spacing(w3, WETH_USDC_POOL, 1) == 10
+
+    w3 = _w3_returning(encode(["uint24"], [500]))
+    assert pool_fee(w3, WETH_USDC_POOL, 1) == 500
+
+    w3 = _w3_returning(encode(["address"], [USDC_ADDRESS]))
+    assert pool_token(w3, WETH_USDC_POOL, "token0", 1) == USDC_ADDRESS
+
+
+def test_eth_call_reverts_become_runtime_error():
+    w3 = MagicMock()
+    w3.eth.call.side_effect = ContractLogicError("revert")
+    with pytest.raises(RuntimeError, match="eth_call reverted"):
+        pool_liquidity(w3, WETH_USDC_POOL, 42)
+
+
+def test_factory_get_pool_decodes_address():
+    w3 = _w3_returning(encode(["address"], [WETH_USDC_POOL]))
+    pool = factory_get_pool(w3, FACTORY, WETH_ADDRESS, USDC_ADDRESS, 500, 1)
+    assert pool == WETH_USDC_POOL
+
+
+def test_multicall_aggregate3_empty_calls():
+    assert multicall_aggregate3(MagicMock(), [], 1) == []
+
+
+def test_multicall_aggregate3_success_and_failed_subcalls():
+    payload = encode(["uint256"], [7])
+    raw = encode(["(bool,bytes)[]"], [[(True, payload), (False, b""), (True, b"")]])
+    w3 = _w3_returning(raw)
+    dummy = encode_call("0x5339c296")
+    out = multicall_aggregate3(
+        w3,
+        [(WETH_USDC_POOL, dummy), (WETH_USDC_POOL, dummy), (WETH_USDC_POOL, dummy)],
+        1,
+    )
+    assert out[0] == payload
+    assert out[1] is None
+    assert out[2] is None
+    w3.eth.call.assert_called_once()
+    tx = w3.eth.call.call_args.args[0]
+    assert tx["to"] == MULTICALL3_ADDRESS
+
+
+def test_multicall_aggregate3_batches():
+    a = encode(["uint256"], [1])
+    b = encode(["uint256"], [2])
+    w3 = MagicMock()
+    w3.eth.call.side_effect = [
+        encode(["(bool,bytes)[]"], [[(True, a)]]),
+        encode(["(bool,bytes)[]"], [[(True, b)]]),
+    ]
+    dummy = encode_call("0x5339c296")
+    out = multicall_aggregate3(
+        w3,
+        [(WETH_USDC_POOL, dummy), (WETH_USDC_POOL, dummy)],
+        1,
+        batch_size=1,
+    )
+    assert out == [a, b]
+    assert w3.eth.call.call_count == 2

--- a/tests/test_uniswap_v3_simulator.py
+++ b/tests/test_uniswap_v3_simulator.py
@@ -1,0 +1,97 @@
+"""Tests for Uniswap v3 swap simulation edge paths."""
+
+from __future__ import annotations
+
+import pytest
+from orion_finance_sdk_py.costs.venues.uniswap_v3.constants import (
+    USDC_ADDRESS,
+    WBTC_ADDRESS,
+    WETH_ADDRESS,
+    WETH_USDC_POOL,
+)
+from orion_finance_sdk_py.costs.venues.uniswap_v3.pool_state import PoolMeta, PoolState
+from orion_finance_sdk_py.costs.venues.uniswap_v3.simulator import (
+    _add_liquidity_delta,
+    _walk_swap,
+    simulate_asset_swap,
+    token_usd_prices,
+)
+from orion_finance_sdk_py.costs.venues.uniswap_v3.v3_math.tick_math import (
+    get_tick_at_sqrt_ratio,
+)
+
+_SQRT_PRICE_X96 = 1905189324021806733252815214030137
+
+
+def _weth_usdc_state(**overrides) -> PoolState:
+    meta = PoolMeta(
+        address=WETH_USDC_POOL,
+        token0=USDC_ADDRESS,
+        token1=WETH_ADDRESS,
+        fee=500,
+        decimals0=6,
+        decimals1=18,
+        tick_spacing=10,
+        stable_token=USDC_ADDRESS,
+        symbol0="USDC",
+        symbol1="WETH",
+    )
+    tick = get_tick_at_sqrt_ratio(_SQRT_PRICE_X96)
+    kwargs = {
+        "meta": meta,
+        "block_number": 1,
+        "sqrt_price_x96": _SQRT_PRICE_X96,
+        "tick": tick,
+        "liquidity": 10**22,
+        "tick_liquidity_net": {},
+        "initialized_ticks": [],
+    }
+    kwargs.update(overrides)
+    return PoolState(**kwargs)
+
+
+def test_simulate_rejects_zero_size():
+    with pytest.raises(ValueError, match="non-zero"):
+        simulate_asset_swap(_weth_usdc_state(), WETH_ADDRESS, 0)
+
+
+def test_simulate_rejects_asset_not_in_pool():
+    with pytest.raises(ValueError, match="is not in pool"):
+        simulate_asset_swap(_weth_usdc_state(), WBTC_ADDRESS, 0.01)
+
+
+def test_token_usd_prices_requires_usdc_pair():
+    state = _weth_usdc_state()
+    state.meta.stable_token = None
+    with pytest.raises(ValueError, match="not a USDC pair"):
+        token_usd_prices(state)
+
+
+def test_walk_swap_zero_remaining_is_noop():
+    state = _weth_usdc_state()
+    amount_in, amount_out, fee, sqrt = _walk_swap(state, 0, True)
+    assert amount_in == 0
+    assert amount_out == 0
+    assert fee == 0
+    assert sqrt == state.sqrt_price_x96
+
+
+def test_add_liquidity_delta_underflow():
+    with pytest.raises(ValueError, match="liquidity underflow"):
+        _add_liquidity_delta(10, -11)
+
+
+def test_swap_crosses_initialized_tick():
+    state = _weth_usdc_state()
+    tick_below = state.tick - 10
+    state.initialized_ticks = [tick_below]
+    state.tick_liquidity_net = {tick_below: 10**18}
+    result = simulate_asset_swap(state, WETH_ADDRESS, 50.0)
+    assert result.amount_out == pytest.approx(50.0)
+    assert result.cost_pct > 0
+
+
+def test_exact_output_unfillable_raises():
+    state = _weth_usdc_state(liquidity=1)
+    with pytest.raises(ValueError, match="cannot fill exact output"):
+        simulate_asset_swap(state, WETH_ADDRESS, 1_000_000.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1618,7 +1618,7 @@ wheels = [
 
 [[package]]
 name = "orion-finance-sdk-py"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cost estimates can now automatically discover and use a public Ethereum mainnet RPC when no RPC URL is configured.
  * RPC selection is cached and falls back across available public endpoints.
  * Added clearer handling for archival endpoints and block-pinned historical queries.

* **Bug Fixes**
  * Improved connection errors and guidance when public RPC discovery fails.
  * Strengthened validation and handling across cost estimation, pool data, RPC calls, and swap simulations.

* **Documentation**
  * Updated installation requirements to SDK version 2.1.1.
  * Documented optional mainnet RPC configuration and fallback behavior.

* **Tests**
  * Expanded coverage for RPC selection, cost estimation, pool state, Uniswap calculations, and simulation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->